### PR TITLE
Fix empty graph for HDBSCAN

### DIFF
--- a/multires_consensus_clustering/graph_community_detection.py
+++ b/multires_consensus_clustering/graph_community_detection.py
@@ -59,7 +59,7 @@ def hdbscan_community_detection(graph):
         # create a distance matrix for the graph if possible
         distance_matrix = mcc.create_distance_matrix(graph)
 
-        clusterer = hdbscan.HDBSCAN(metric="precomputed", min_samples=2).fit(distance_matrix)
+        clusterer = hdbscan.HDBSCAN(metric="precomputed", min_samples=2, allow_single_cluster=True).fit(distance_matrix)
         labels = clusterer.labels_
 
         # hdbscan has an integrated outlier detection for clustering -> delete those nodes

--- a/multires_consensus_clustering/merge_resolution_graphs.py
+++ b/multires_consensus_clustering/merge_resolution_graphs.py
@@ -268,8 +268,8 @@ def multires_community_detection(graph, clustering_data, community_detection, me
     if community_detection == "leiden":
         # uses the leiden algorithm for community detection
         vertex_clustering = ig.Graph.community_leiden(graph, weights="weight")
-    elif community_detection == "hdbscan":
-        # uses the hdbscan for community detection
+    elif community_detection == "hdbscan" and graph.vcount() > 1 and graph.ecount() > 0:
+        # use hdbscan for community detection
         vertex_clustering = mcc.hdbscan_community_detection(graph)
     elif community_detection == "component":
         # splits the graph into components and merges these components into a single node


### PR DESCRIPTION
Check if the graph has more than one node and at least one edge before running HDBSCAN.

Also allow single nodes in the clustering step of HDBSCAN.