### PR TITLE
Fix bug in exception handling for HDBSCAN.

### DIFF
--- a/multires_consensus_clustering/graph_community_detection.py
+++ b/multires_consensus_clustering/graph_community_detection.py
@@ -92,7 +92,7 @@ def hdbscan_community_detection(graph):
     # if infinite distances catches case by running leiden community detection.
     else:
         print("Graph has distances np.inf, thus HDBscan won't compute.")
-        vertex_clustering = igraph_community_detection(graph, "leiden")
+        vertex_clustering = igraph_community_detection(graph, "leiden", resolution=1)
 
     return vertex_clustering
 


### PR DESCRIPTION
Add the resolution parameter to HBDSCAN community detection.

Parameter is set to standard value 1 (leiden) if HDBSCAN can not be computed.